### PR TITLE
Dummy commit to trigger an action in GH

### DIFF
--- a/.github/workflows/daily-job.yml
+++ b/.github/workflows/daily-job.yml
@@ -3,7 +3,7 @@ name: Daily job
 on:
   schedule:
     # To set specific time please check https://crontab.guru
-    - cron:  '0 6 * * *'
+    - cron:  '0 7 * * *'
 
 jobs:
   trigger:


### PR DESCRIPTION
Schedule workflow stops after 60 days of inactivity, so a dummy commit should help. Later we can find a better solution.